### PR TITLE
Distribute files into subdirs, and add support for CAPTCHA detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.idea
 /target/

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use axum::{Extension, Router};
-use freshrss_image_cache_service_rs::app_service::AppService;
+use freshrss_image_cache_service_rs::app_service::{AppService, CloudFlareBypassProxy};
 use freshrss_image_cache_service_rs::handlers::root_router;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -15,6 +15,19 @@ async fn main() -> Result<()> {
     let images_dir = std::env::var("APP_IMAGES_DIR").with_context(|| "APP_IMAGES_DIR")?;
     let no_colors = std::env::var("APP_NO_ANSI_COLORS").is_err();
 
+    let cloudflare_proxy = std::env::var("APP_CLOUDFLARE_PROXY").ok();
+    let cloudflare_proxy_login = std::env::var("APP_CLOUDFLARE_PROXY_LOGIN").ok();
+    let cloudflare_proxy_pass = std::env::var("APP_CLOUDFLARE_PROXY_PASS").ok();
+
+    let bypass_info = match (cloudflare_proxy, cloudflare_proxy_login, cloudflare_proxy_pass) {
+        (Some(proxy), Some(login), Some(pass)) => Some(CloudFlareBypassProxy {
+            proxy_url: proxy,
+            proxy_login: login,
+            proxy_password: pass,
+        }),
+        _ => None,
+    };
+
     let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
 
     tracing_subscriber::fmt()
@@ -28,13 +41,15 @@ async fn main() -> Result<()> {
     info!("Listening on http://{}", listener.local_addr()?);
 
     let app_service = Arc::new(AppService::new(access_token.clone(),
-                                               PathBuf::from(images_dir.clone()), false));
+                                               PathBuf::from(images_dir.clone()),
+                                               false, bypass_info.clone()));
     let safe = Router::new()
         .nest("/", root_router())
         .layer(Extension(app_service));
 
     let unsafe_app = Arc::new(AppService::new(access_token.clone(),
-                                              PathBuf::from(images_dir.clone()), true));
+                                              PathBuf::from(images_dir.clone()),
+                                              true, bypass_info));
     let unsafe_router = Router::new()
         .nest("/", root_router())
         .layer(Extension(unsafe_app));


### PR DESCRIPTION
ImageCache right now puts all the files in one directory, and it can get pretty large, creating problems for various tools. Distribute files into subdirs, based on the first two characters of the file name.

Additionally, CloudFlare sometimes injects CAPTCHAs into images. Avoid storing them.